### PR TITLE
Improve builder interface

### DIFF
--- a/lib/phlex/rails.rb
+++ b/lib/phlex/rails.rb
@@ -56,6 +56,8 @@ module Phlex
 			loader.collapse("#{__dir__}/phlex/errors")
 			loader.setup
 		end
+
+		extend Phlex::Rails::Types
 	end
 
 	CSV.prepend(Phlex::Rails::CSV)

--- a/lib/phlex/rails/buffered.rb
+++ b/lib/phlex/rails/buffered.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module Phlex::Rails
-	def Buffered(type)
-		-> (value) { Phlex::Rails::Buffered === value && type === value.unwrap }
-	end
-
 	class Buffered < BasicObject
 		def initialize(object, component:)
 			@object = object

--- a/lib/phlex/rails/builder.rb
+++ b/lib/phlex/rails/builder.rb
@@ -7,6 +7,16 @@ class Phlex::Rails::Builder < BasicObject
 	end
 
 	define_method :send, ::Kernel.instance_method(:send)
+	define_method :class, ::Kernel.instance_method(:class)
+	define_method :is_a?, ::Kernel.instance_method(:is_a?)
+
+	def inspect
+		"Phlex::Rails::Builder(#{@object.inspect})"
+	end
+
+	def unwrap
+		@object
+	end
 
 	def respond_to_missing?(method_name, include_private = false)
 		@object.respond_to?(method_name, include_private)

--- a/lib/phlex/rails/types.rb
+++ b/lib/phlex/rails/types.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Phlex
+	module Rails
+		module Types
+			def Buffered(type)
+				-> (value) { Phlex::Rails::Buffered === value && type === value.unwrap }
+			end
+
+			def Builder(type)
+				-> (value) { Phlex::Rails::Builder === value && type === value.unwrap }
+			end
+		end
+	end
+end

--- a/test/buffered.test.rb
+++ b/test/buffered.test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+test "is clear about type" do
+	buffered = Phlex::Rails::Buffered.new(nil, component: nil)
+	assert_equal buffered.class, Phlex::Rails::Buffered
+	assert buffered.is_a?(Phlex::Rails::Buffered)
+end
+
+test "can unwrap object" do
+	object = Object.new
+	buffered = Phlex::Rails::Buffered.new(object, component: nil)
+	assert_equal object, buffered.unwrap
+end
+
+test "is clear when inspected" do
+	buffered = Phlex::Rails::Buffered.new(nil, component: nil)
+	assert_equal buffered.inspect, "Phlex::Rails::Buffered(nil)"
+end

--- a/test/builder.test.rb
+++ b/test/builder.test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+test "is clear about type" do
+	builder = Phlex::Rails::Builder.new(nil, component: nil)
+	assert_equal builder.class, Phlex::Rails::Builder
+	assert builder.is_a?(Phlex::Rails::Builder)
+end
+
+test "can unwrap object" do
+	object = Object.new
+	builder = Phlex::Rails::Builder.new(object, component: nil)
+	assert_equal object, builder.unwrap
+end
+
+test "is clear when inspected" do
+	buffered = Phlex::Rails::Builder.new(nil, component: nil)
+	assert_equal buffered.inspect, "Phlex::Rails::Builder(nil)"
+end

--- a/test/types.test.rb
+++ b/test/types.test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+test "buffered type" do
+	type = Phlex::Rails::Buffered(ActionView::Helpers::TagHelper::TagBuilder)
+	tag = ActionController::Base.new.view_context.tag
+	assert type === Phlex::Rails::Buffered.new(tag, component: nil)
+	refute type === Phlex::Rails::Buffered.new(nil, component: nil)
+	refute type === "not buffered"
+end
+
+test "builder type" do
+	type = Phlex::Rails::Builder(ActionView::Helpers::FormBuilder)
+	ActionController::Base.new.view_context.form_with(url: "/", method: :get) do |form|
+		assert type === Phlex::Rails::Builder.new(form, component: nil)
+	end
+	refute type === Phlex::Rails::Builder.new(nil, component: nil)
+	refute type === "not adapted builder"
+end


### PR DESCRIPTION
This follows the pattern set in #298. It was supposed to close #296, but I'm still seeing an issue there after upgrading to 2.3.1. It seems that `Phlex::Rails::Buffered` is not used for the adapted form builders, `Phlex::Rails::Builder` is, after #291. I've basically updated `Builder` to match `Buffered` in how it reports its own class, and added tests for both.

Additionally, I extracted the "type" methods to a `Phlex::Rails::Types` module that `Phlex::Rails` extends just after setting up the Zeitwerk loader. Defining the type methods alongside the class definitions resulted in a problem where those methods were not available until the class had been loaded. So e.g. in development `prop :form, Phlex::Rails::Builder(ActionView::Helpers::FormBuilder)` would result in `undefined method 'Builder' for Phlex::Rails:Module` unless `Phlex::Rails::Builder` was called prior, which I had no reason to do. Maybe there's a better way to handle this, but this got things working.