### PR TITLE
Allow `register_output_helper` to mark output safe before call to `raw`

### DIFF
--- a/lib/phlex/rails/helper_macros.rb
+++ b/lib/phlex/rails/helper_macros.rb
@@ -2,7 +2,7 @@
 
 module Phlex::Rails::HelperMacros
 	# Register a Rails helper that returns safe HTML to be pushed to the output buffer.
-	def register_output_helper(method_name)
+	def register_output_helper(method_name, mark_safe: false)
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 			# frozen_string_literal: true
 
@@ -13,7 +13,7 @@ module Phlex::Rails::HelperMacros
 					view_context.#{method_name}(*args, **kwargs)
 				end
 
-				raw(output)
+				raw(#{mark_safe ? 'safe(output)' : 'output'})
 			end
 		RUBY
 	end

--- a/test/helper_macros.test.rb
+++ b/test/helper_macros.test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+test "register_output_helper with raw marked safe" do
+	view_ctx = ActionController::Base.new.view_context
+	view_ctx.define_singleton_method(:raw_html_producing_method) { "<span>ok</span>" }
+
+	component = Class.new(Phlex::HTML) do
+		register_output_helper :raw_html_producing_method, mark_safe: true
+
+		def view_template
+			div { raw_html_producing_method }
+		end
+	end
+
+	assert_equivalent_html component.render_in(view_ctx), "<div><span>ok</span></div>"
+end
+
+test "register_output_helper with raw not marked safe (default)" do
+	view_ctx = ActionController::Base.new.view_context
+	view_ctx.define_singleton_method(:raw_html_producing_method) { "<span>ok</span>" }
+
+	component = Class.new(Phlex::HTML) do
+		register_output_helper :raw_html_producing_method
+
+		def view_template
+			div { raw_html_producing_method }
+		end
+	end
+
+	error = assert_raises Phlex::ArgumentError do
+		component.render_in(view_ctx)
+	end
+	assert_equal error.message, "You passed an unsafe object to `raw`."
+end


### PR DESCRIPTION
This PR provides a way to register output helpers that return raw HTML that is not already marked safe.

The demonstrated use case [in the docs](https://www.phlex.fun/rails/helpers.html#registering-custom-helper-adapters) for `register_output_helper` is `pagy_nav`. But `pagy_nav` does not mark its output safe, it [manually builds HTML as a plain string](https://github.com/ddnexus/pagy/blob/3b4745cb6c550a5799a520115750f801021364ce/gem/lib/pagy/frontend.rb#L49-L68).

So registering `pagy_nav` as the docs instruct and then attempting to use it results in a `Phlex::ArgumentError` with "You passed an unsafe object to `raw`.". Getting around this requires either:

A) not registering `pagy_nav`, including its containing module, and then registering the request object _it_ needs for building out the pagination links:

```ruby
class MyComponent < Phlex::HTML
  include Pagy::Frontend
  register_value_helper :request
  def view_template
    raw safe(pagy_nav(...))
  end
end
```

B) registering `pagy_nav` as a value helper:

```ruby
class MyComponent < Phlex::HTML
  register_value_helper :pagy_nav
  def view_template
    raw safe(pagy_nav(...))
  end
end
```

B is less involved because it doesn't require supplying Pagy its own dependencies like in A. But there is still the friction of needing to call  `raw safe()` around every call to `pagy_nav`, and the resulting repeated `safe` calls which is arguably an unsafe habit.

The change in this PR allows `register_output_helper` to mark the helper output safe before it is sent to `raw`, so the helper can be used without calls to `raw` or `safe`:

```ruby
class MyComponent < Phlex::HTML
  register_output_helper :pagy_nav, mark_safe: true
  def view_template
    pagy_nav(...)
  end
end
```

I think this is preferable because it minimizes `safe` calls by the user. I'm not at all attached to the implementation; this could just as easily be a separate helper, maybe `register_unsafe_output_helper`, if we don't want to alter the guaranteed safety of `register_output_helper`.